### PR TITLE
feat: created ClickUp teams template

### DIFF
--- a/templates/clickup/teams-list/CHANGELOG.md
+++ b/templates/clickup/teams-list/CHANGELOG.md
@@ -1,0 +1,12 @@
+# 📣 Change Log
+All notable changes to the `clickup/teams-list` template will be documented in this file.
+
+The format followed is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
+
+---
+ 
+## [1.0.0] - 2022-06-02
+ 
+⚡️ Initial Version
+ 
+---

--- a/templates/clickup/teams-list/config.json
+++ b/templates/clickup/teams-list/config.json
@@ -1,5 +1,5 @@
 {
-  "name": "teams_listResult",
+  "name": "teams",
   "title": "List all teams in a ClickUp workspace",
   "description": "List all teams in a ClickUp workspace using the ClickUp Api",
   "type": "js-request-function",

--- a/templates/clickup/teams-list/config.json
+++ b/templates/clickup/teams-list/config.json
@@ -1,6 +1,6 @@
 {
   "name": "teams",
-  "title": "List all teams in a ClickUp workspace",
+  "title": "List teams",
   "description": "List all teams in a ClickUp workspace using the ClickUp Api",
   "type": "js-request-function",
   "envVars": {
@@ -9,8 +9,8 @@
       "production": ""
     }, 
     "CLICKUP_API_URL": {
-      "development": "https://api.clickup.com/api/v2/",
-      "production": "https://api.clickup.com/api/v2/"
+      "development": "https://api.clickup.com/api/v2",
+      "production": "https://api.clickup.com/api/v2"
     }
   },
   "fee": 0,

--- a/templates/clickup/teams-list/config.json
+++ b/templates/clickup/teams-list/config.json
@@ -7,16 +7,20 @@
     "CLICKUP_API_TOKEN": {
       "development": "",
       "production": ""
+    }, 
+    "CLICKUP_API_URL": {
+      "development": "https://api.clickup.com/api/v2/",
+      "production": "https://api.clickup.com/api/v2/"
     }
   },
   "fee": 0,
-  "image": "https://github.com/LaunchUpCorp/PublicAssets/blob/main/ClickUpIcons/desktop%20app%20-%20white%20rounded.svg",
-  "category": "",
+  "image": "https://assets.buildable.dev/catalog/node-templates/clickup.svg",
+  "category": "productivity",
   "accessType": "open",
   "language": "javascript",
   "price": "free",
   "platform": "clickup",
-  "tags": ["business","project managment","agile"],
+  "tags": ["business","projects","teams"],
   "stateType": "stateless",
   "__version": "1.0.0"
 }

--- a/templates/clickup/teams-list/config.json
+++ b/templates/clickup/teams-list/config.json
@@ -1,0 +1,23 @@
+{
+  "name": "teams_listResult",
+  "title": "List all teams in a ClickUp workspace",
+  "description": "List all teams in a ClickUp workspace using the ClickUp Api",
+  "type": "js-request-function",
+  "envVars": {
+    "CLICKUP_API_TOKEN": {
+      "development": "",
+      "production": ""
+    }
+  },
+  "fee": 0,
+  "image": "https://github.com/LaunchUpCorp/PublicAssets/blob/main/ClickUpIcons/desktop%20app%20-%20white%20rounded.svg",
+  "category": "",
+  "accessType": "open",
+  "language": "javascript",
+  "price": "free",
+  "platform": "clickup",
+  "tags": ["business","project managment","agile"],
+  "stateType": "stateless",
+  "__version": "1.0.0"
+}
+

--- a/templates/clickup/teams-list/input.js
+++ b/templates/clickup/teams-list/input.js
@@ -1,0 +1,24 @@
+/**
+ * ----------------------------------------------------------------------------------------------------
+ * List All Teams in Workspace [Input]
+ *
+ * @author    Launch Up corp.
+ * @access    open
+ * @license   MIT
+ * @docs      https://clickup.com/api
+ *
+ * ----------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Lets you select the input for your Node's run function
+ *
+ * @param {Params} params
+ * @param {Object} $trigger - This Flow's request object
+ * @param {Object} $nodes - Data from above Nodes
+ */
+const nodeInput = ({ $trigger, $nodes }) => {
+  return {
+    CLICKUP_API_TOKEN: $trigger.env.CLICKUP_API_TOKEN, // Required
+  };
+};

--- a/templates/clickup/teams-list/input.js
+++ b/templates/clickup/teams-list/input.js
@@ -2,7 +2,7 @@
  * ----------------------------------------------------------------------------------------------------
  * List All Teams in Workspace [Input]
  *
- * @author    Launch Up corp.
+ * @author    LaunchUp Technology Ltd.
  * @access    open
  * @license   MIT
  * @docs      https://clickup.com/api

--- a/templates/clickup/teams-list/input.js
+++ b/templates/clickup/teams-list/input.js
@@ -20,5 +20,6 @@
 const nodeInput = ({ $trigger, $nodes }) => {
   return {
     CLICKUP_API_TOKEN: $trigger.env.CLICKUP_API_TOKEN, // Required
+    CLICKUP_API_URL: $trigger.env.CLICKUP_API_URL, // Required
   };
 };

--- a/templates/clickup/teams-list/run.js
+++ b/templates/clickup/teams-list/run.js
@@ -2,7 +2,7 @@
  * ----------------------------------------------------------------------------------------------------
  * List All User Groups for a Team [Run]
  *
- * @author    Launch Up corp.
+ * @author    LaunchUp Technology Ltd.
  * @access    open
  * @license   MIT
  * @docs      https://clickup.com/api

--- a/templates/clickup/teams-list/run.js
+++ b/templates/clickup/teams-list/run.js
@@ -1,0 +1,52 @@
+/**
+ * ----------------------------------------------------------------------------------------------------
+ * List All User Groups for a Team [Run]
+ *
+ * @author    Launch Up corp.
+ * @access    open
+ * @license   MIT
+ * @docs      https://clickup.com/api
+ *
+ * ----------------------------------------------------------------------------------------------------
+ */
+
+const axios = require("axios");
+
+/**
+ * The Node’s executable function
+ *
+ * @param {Run} input - Data passed to your Node from the input function
+ */
+const run = async (input) => {
+  const { CLICKUP_API_TOKEN } = input;
+
+  verifyInput(input);
+
+  try {
+    const { data } = await axios({
+      method: "get",
+      url: "https://api.clickup.com/api/v2/team",
+      headers: { Authorization: `${CLICKUP_API_TOKEN}` },
+    });
+
+    return data;
+  } catch (error) {
+    return {
+      failed: true,
+      message: error.message,
+      data: error.response.data,
+    };
+  }
+};
+
+/**
+ * Verifies the input parameters
+ */
+const verifyInput = ({ CLICKUP_API_TOKEN }) => {
+  const ERRORS = {
+    INVALID_CLICKUP_API_TOKEN:
+      "A valid CLICKUP_API_TOKEN field (string) was not provided in the input.",
+  };
+
+  if (typeof CLICKUP_API_TOKEN !== "string") throw new Error(ERRORS.INVALID_CLICKUP_API_TOKEN);
+};

--- a/templates/clickup/teams-list/run.js
+++ b/templates/clickup/teams-list/run.js
@@ -25,7 +25,7 @@ const run = async (input) => {
   try {
     const { data } = await axios({
       method: "get",
-      url: CLICKUP_API_URL,
+      url: `${CLICKUP_API_URL}/team`,
       headers: { Authorization: `${CLICKUP_API_TOKEN}` },
     });
 

--- a/templates/clickup/teams-list/run.js
+++ b/templates/clickup/teams-list/run.js
@@ -18,14 +18,14 @@ const axios = require("axios");
  * @param {Run} input - Data passed to your Node from the input function
  */
 const run = async (input) => {
-  const { CLICKUP_API_TOKEN } = input;
+  const { CLICKUP_API_TOKEN, CLICKUP_API_URL } = input;
 
   verifyInput(input);
 
   try {
     const { data } = await axios({
       method: "get",
-      url: "https://api.clickup.com/api/v2/team",
+      url: CLICKUP_API_URL,
       headers: { Authorization: `${CLICKUP_API_TOKEN}` },
     });
 


### PR DESCRIPTION
###  ClickUp list teams template

I have created a template to retrieve a ClickUp workspace team info.  The teams object has information about each of the users in the team as well as info about the team itself. 

More info on the ClickUp API: https://clickup.com/api

Placed it under a new folder for ClickUp with ClickUp being the platform as well for future ClickUp template work.

I have tested the template within buildable. 
![image](https://user-images.githubusercontent.com/104530466/171772453-05fa24cd-a4f7-4433-a474-a6f866fdb0ab.png)

I am unsure about which tags to add are required.

Was unsure where the icons should be stored so I uploaded them to a public Repo and linked to that.  