### PR TITLE
Fix checkout.com init response

### DIFF
--- a/sources/catalog/checkout/checkout.ts
+++ b/sources/catalog/checkout/checkout.ts
@@ -81,7 +81,7 @@ export default class CheckoutIntegration implements IntegrationClassI {
       });
 
       return {
-        webhookData: webhooks.data.id,
+        webhookData: webhooks.data,
         events
       }
     } catch(error) {

--- a/sources/tests/checkout.test.ts
+++ b/sources/tests/checkout.test.ts
@@ -84,6 +84,7 @@ describe("Checkout Integration", () => {
         events,
       });
       expect(webhook.webhookData).toBeDefined();
+      expect(webhook.webhookData['id']).toBeDefined();
       expect(webhook.events).toEqual(events);
     });
 
@@ -267,7 +268,10 @@ async function createWebhook(events: string[] = defaultEvents): Promise<string> 
     webhookUrl: 'https://example.com',
     events,
   });
-  return (webhook.webhookData as unknown as string);
+  if (!webhook.webhookData.hasOwnProperty('id')) {
+    throw new Error('Error creating webhook');
+  }
+  return webhook.webhookData['id'];
 }
 
 async function deleteWebhook(webhookId: string) {


### PR DESCRIPTION
While testing, I was getting some 404s while updating subscriptions, and I believe this could be because I was returning the webhook data in the wrong shape.

Before, `init` will return:
```
{
  webhookData: 'webhook-id',
  events: ['event-1', 'event-2'],
}
```

After, `init` will return:
```
{
  webhookData: {
    id: 'webhook-id',
    // some other fields
  },
  events: [//...],
}
```