### PR TITLE
Adyen Integration - Hotfix

### DIFF
--- a/sources/catalog/adyen/config.json
+++ b/sources/catalog/adyen/config.json
@@ -77,7 +77,7 @@
       "group": ""
     },
     {
-      "name": "account-settings-notifications",
+      "name": "account-settings-notification",
       "description": "Receive a notification when there is a status change related to your company account, merchant account, or store.",
       "group": ""
     },


### PR DESCRIPTION
This PR fixes `"account-settings-notification"` event name to exactly match Adyen's naming.