### PR TITLE
Checkout.com integration fixes

### DIFF
--- a/sources/catalog/checkout/checkout.ts
+++ b/sources/catalog/checkout/checkout.ts
@@ -191,7 +191,10 @@ export default class CheckoutIntegration implements IntegrationClassI {
   async testConnection(): Promise<Truthy> {
     try {
       await this.checkout.get('/');
-      return true;
+      return {
+        success: true,
+        message: "Connection tested successfully!",
+      };
     } catch(err) {
       throw new Error(`Error connecting to checkout.com API: ${err.message}`);
     }

--- a/sources/catalog/checkout/config.json
+++ b/sources/catalog/checkout/config.json
@@ -337,11 +337,6 @@
       "group": "platforms"
     },
     {
-      "name": "dispute.dispute_arbitration_lost",
-      "description": "Occurs when an arbitration has been lost. Your account will be debited any additional arbitration-related fees.",
-      "group": "platforms"
-    },
-    {
       "name": "fincrime.payment_compliance_review",
       "description": "Occurs when a payment is pending while under compliance review.",
       "group": "fincrime"

--- a/sources/tests/checkout.test.ts
+++ b/sources/tests/checkout.test.ts
@@ -249,7 +249,10 @@ describe("Checkout Integration", () => {
   describe("testConnection", () => {
     it("should return true if the connection is valid", async () => {
       const result = await checkout.testConnection();
-      expect(result).toBeTruthy();
+      expect(result).toEqual(expect.objectContaining({
+        success: true,
+        message: "Connection tested successfully!",
+      }));
     });
 
     it("should throw an error if something goes wrong with the connection", async () => {


### PR DESCRIPTION
Another round of minor fixes. This should fix the connection test message and remove an acidently duplicated event. 