### PR TITLE
[HOTFIX] BigQuery Destination: Attempt connection to BigQuery while testing connection

### DIFF
--- a/catalog/destinations/bigquery/bigquery.ts
+++ b/catalog/destinations/bigquery/bigquery.ts
@@ -34,7 +34,7 @@ export class BigQueryDriver implements DestinationClassI {
 
   async testConnection(): Promise<TestConnection> {
     if (!this.client) {
-      throw new Error("Connection to BigQuery not established");
+      await this.connect();
     }
 
     // A sample query
@@ -123,7 +123,6 @@ export class BigQueryDriver implements DestinationClassI {
     `;
 
     // execute query
-
     return bqTable.query(updateQuery);
   }
 


### PR DESCRIPTION
This hotfix calls `connect()` method if the client is not yet initialized while calling `testConnection()`. Since Buildable does not call `connect()` internally before issuing a connection test. It is mandatory to do the call in the scope of `testConnection()`.